### PR TITLE
Hotfix for frontend_display function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ License: [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 
 ## Changelog
 
+### 4.0.3
+
+* Resolved syntax issue that resulted in only last related item being output
+
 ### 4.0.2
 
 * WordPress 5.7.2 has JQuery UI Sortable require Draggable and Droppable as well

--- a/README.txt
+++ b/README.txt
@@ -27,6 +27,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 4.0.3 =
+* Resolved syntax issue that resulted in only last related item being output
+
 = 4.0.2 =
 * WordPress 5.7.2 has JQuery UI Sortable require Draggable and Droppable as well
 

--- a/bvi-related-items.php
+++ b/bvi-related-items.php
@@ -12,7 +12,7 @@
  * Plugin Name:       BVI Related Items
  * Plugin URI:        https://github.com/bigvoodoo/bvi-related-items
  * Description:       This will allow you to set custom related items, either posts or pages, to a specific set of pages through shortcode [related-items]
- * Version:           4.0.2
+ * Version:           4.0.3
  * Requires at least: 5.6
  * Requires PHP:      7.2
  * Author:            Big Voodoo Interactive

--- a/includes/class-bvi-related-items.php
+++ b/includes/class-bvi-related-items.php
@@ -240,7 +240,7 @@ class Bvi_Related_Items {
 			$list_output .= '<ul class="related-items-menu">';
 			// put all those fancy lis in a happy little ul
 			foreach($list_data as $item => $data){
-				$list_output = $data;
+				$list_output .= $data;
 			}
 
 			$list_output .= '</ul>';


### PR DESCRIPTION
hotfix: fixed syntax error in frontend_display, resulting in only last related link being returned