### PR TITLE
PHP Warning in Admin Fix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: geekmenina
 Donate link: https://www.bigvoodoo.com
 Tags: links, related links
 Requires at least: 5.5.1
-Tested up to: 6.2
+Tested up to: 6.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,9 @@ This section describes how to install the plugin and get it working.
 1. Use the `[related-items]` shortcode to display the related items.
 
 == Changelog ==
+
+= 4.0.5 =
+* Removes unused class variable, removing warning error in WP admin
 
 = 4.0.4 =
 * Replaced deprecated get_page_by_title() with WP_Query in frontend_display() function

--- a/admin/class-bvi-related-items-admin.php
+++ b/admin/class-bvi-related-items-admin.php
@@ -104,7 +104,7 @@ class Bvi_Related_Items_Admin {
 	 */
 	public function add_options_page() {
 	
-		$this->plugin_screen_hook_suffix = add_options_page(
+		add_options_page(
 			__( 'BVI Related Items Settings', $this->plugin_name ),
 			__( 'BVI Related Items', $this->plugin_name ),
 			'manage_options',

--- a/bvi-related-items.php
+++ b/bvi-related-items.php
@@ -12,7 +12,7 @@
  * Plugin Name:       BVI Related Items
  * Plugin URI:        https://github.com/bigvoodoo/bvi-related-items
  * Description:       This will allow you to set custom related items, either posts or pages, to a specific set of pages through shortcode [related-items]
- * Version:           4.0.4
+ * Version:           4.0.5
  * Requires at least: 5.6
  * Requires PHP:      7.2
  * Author:            Big Voodoo Interactive


### PR DESCRIPTION
Removes unnecessary reference to non-existent class variable to remove warning in admin